### PR TITLE
Fix hint content display by using unique IDs and DOM retrieval

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -177,19 +177,35 @@ class QuizView
     def create_hints
         hints_container = document.getElementById('hints-container')
         template = document.querySelector('#hint-template')
-        @quiz.hints.each do |hint|
+        @quiz.hints.each_with_index do |hint, index|
             clone = template[:content].cloneNode(true)
             button = clone.querySelector('.hint-button')
-            button[:innerText] = "#{hint.desc} <#{hint.cost}>"
             hint_content = clone.querySelector('.hint-content')
+
+            # 一意のIDを設定
+            hint_content_id = "hint-content-#{index}"
+            hint_content[:id] = hint_content_id
+            button[:innerText] = "#{hint.desc} <#{hint.cost}>"
+
+            # DOMに追加
+            hints_container.appendChild(clone)
+
+            # イベントリスナーを追加（DOM追加後）
             button.addEventListener('click') do
                 @quiz.hint!(hint)
                 update_score!
                 animate_score!(false)
                 button[:disabled] = true
-                hint_content[:innerText] = hint.content.to_s
+
+                # DOMから直接取得
+                content_element = document.getElementById(hint_content_id)
+                content_element[:innerText] = hint.content.to_s
+
+                # デバッグ用
+                puts "Hint clicked: #{hint.desc}"
+                puts "Content: #{hint.content}"
+                puts "Element found: #{!content_element.nil?}"
             end
-            hints_container.appendChild(clone)
         end
     end
 


### PR DESCRIPTION
The issue was that references to cloned template elements were not properly maintained in event listener closures after appendChild.

Solution:
- Assign unique IDs to each hint-content element
- Retrieve elements by ID within event listeners after DOM insertion
- Add debug logging to verify hint display functionality