### PR TITLE
Fix setTimeout TypeError in animate_score! method

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -169,9 +169,9 @@ class QuizView
         score_element[:classList].remove('score-up')
         score_element[:classList].remove('score-down')
 
-        JS.global[:setTimeout].call(-> {
-            score_element[:classList].add(is_up ? 'score-up' : 'score-down')
-        }, 10)
+        # CSSアニメーションをトリガーするためにsetTimeoutを使用
+        class_name = is_up ? 'score-up' : 'score-down'
+        JS.eval("setTimeout(function() { document.getElementById('score').classList.add('#{class_name}'); }, 10);")
     end
 
     def create_hints


### PR DESCRIPTION
The JS.global[:setTimeout].call syntax is not supported in ruby.wasm and causes TypeError: Function.prototype.apply was called on undefined.

This error was blocking hint display because animate_score! is called before the hint content is shown, causing the entire click handler to fail.

Solution: Use JS.eval with direct JavaScript setTimeout call instead. This allows the hint display logic (already fixed in previous commits) to execute successfully.