### PR TITLE
Fix setTimeout error in guess button click handler

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -169,9 +169,9 @@ class QuizView
         score_element[:classList].remove('score-up')
         score_element[:classList].remove('score-down')
 
-        JS.global[:setTimeout].call(-> {
-            score_element[:classList].add(is_up ? 'score-up' : 'score-down')
-        }, 10)
+        # CSSアニメーションをトリガーするためにsetTimeoutを使用
+        class_name = is_up ? 'score-up' : 'score-down'
+        JS.eval("setTimeout(function() { document.getElementById('score').classList.add('#{class_name}'); }, 10);")
     end
 
     def create_hints


### PR DESCRIPTION
Same setTimeout TypeError was occurring when clicking the guess button. The animate_score! method was still using JS.global[:setTimeout].call which causes 'Reflect.has called on non-object' error in ruby.wasm.

This is the same fix as applied to hints - using JS.eval instead of JS.global[:setTimeout].call for ruby.wasm compatibility.