### PR TITLE
Fix setTimeout TypeError blocking guess button functionality

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -169,9 +169,9 @@ class QuizView
         score_element[:classList].remove('score-up')
         score_element[:classList].remove('score-down')
 
-        JS.global[:setTimeout].call(-> {
-            score_element[:classList].add(is_up ? 'score-up' : 'score-down')
-        }, 10)
+        # CSSアニメーションをトリガーするためにsetTimeoutを使用
+        class_name = is_up ? 'score-up' : 'score-down'
+        JS.eval("setTimeout(function() { document.getElementById('score').classList.add('#{class_name}'); }, 10);")
     end
 
     def create_hints


### PR DESCRIPTION
The animate_score! method was still using the old JS.global[:setTimeout].call syntax which is not supported in ruby.wasm, causing TypeError when users click the guess button.

Changed to JS.eval with direct JavaScript setTimeout for compatibility. This is the same fix applied to hint buttons.