### PR TITLE
Fix localStorage access using JS.eval instead of JS.global

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -42,14 +42,12 @@ class GameStats
     private
 
     def load_from_storage(key)
-        storage = JS.global[:localStorage]
-        value = storage.getItem("rubyGuesser_#{key}")
-        value.nil? ? '0' : value.to_s
+        result = JS.eval("localStorage.getItem('rubyGuesser_#{key}')")
+        result.nil? || result.to_s == 'null' ? '0' : result.to_s
     end
 
     def save_to_storage(key, value)
-        storage = JS.global[:localStorage]
-        storage.setItem("rubyGuesser_#{key}", value.to_s)
+        JS.eval("localStorage.setItem('rubyGuesser_#{key}', '#{value}')")
     end
 end
 


### PR DESCRIPTION
The 'Reflect.has called on non-object' error was caused by improper localStorage access through JS.global[:localStorage].

Changed to use JS.eval for direct JavaScript execution:
- localStorage.getItem()
- localStorage.setItem()

This matches the pattern used for setTimeout and should resolve the error when clicking the guess button.