### PR TITLE
Fix all JS.global usage - use JS.eval for localStorage and location.r…

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -42,14 +42,12 @@ class GameStats
     private
 
     def load_from_storage(key)
-        storage = JS.global[:localStorage]
-        value = storage.getItem("rubyGuesser_#{key}")
-        value.nil? ? '0' : value.to_s
+        result = JS.eval("localStorage.getItem('rubyGuesser_#{key}')")
+        result.nil? || result.to_s == 'null' ? '0' : result.to_s
     end
 
     def save_to_storage(key, value)
-        storage = JS.global[:localStorage]
-        storage.setItem("rubyGuesser_#{key}", value.to_s)
+        JS.eval("localStorage.setItem('rubyGuesser_#{key}', '#{value}')")
     end
 end
 
@@ -306,7 +304,7 @@ class QuizView
                     button[:className] = 'restart-button'
                     button[:innerText] = '🎉 Next Challenge! 🎉'
                     button.addEventListener('click') do
-                        JS.global[:location].reload
+                        JS.eval("location.reload()")
                     end
                     document.querySelector('.input-group').appendChild(button)
                 end


### PR DESCRIPTION
…eload

Replaced all problematic JS.global calls with JS.eval:
- localStorage.getItem/setItem (lines 45-50)
- location.reload() (line 307)

This should resolve the 'Reflect.has called on non-object' error that occurs when clicking the guess button.